### PR TITLE
resinos-in-container.sh: Various improvements

### DIFF
--- a/conf/systemd-watchdog.conf
+++ b/conf/systemd-watchdog.conf
@@ -1,0 +1,2 @@
+[Manager]
+RuntimeWatchdogSec=0


### PR DESCRIPTION
Stop mounting host's kernel modules as we want to minimize changes on the host
and if there are kernel requirements they need to be satisfied before running
resinOS in container.

Replace the way to preload the volume with a `docker run` command. This removes the sudo dependency.

Deactivate systemd watchdog in resinOS container

Signed-off-by: Andrei Gherzan <andrei@resin.io>