### PR TITLE
Missing realpath workaround for Mac OS  X systems

### DIFF
--- a/resinos-in-container.sh
+++ b/resinos-in-container.sh
@@ -39,11 +39,11 @@ EOF
 }
 
 # realpath is not available on Mac OS, define it as a bash function if it's not found
-if [ ! -f "/usr/bin/realpath" ] && [ ! -f "/bin/realpath" ]; then
+command -v realpath >/dev/null 2>&1 || {
     realpath() {
         [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
     }
-fi
+}
 
 # Parse arguments
 while [[ $# -ge 1 ]]; do

--- a/resinos-in-container.sh
+++ b/resinos-in-container.sh
@@ -38,6 +38,13 @@ ARGUMENTS:
 EOF
 }
 
+# realpath is not available on Mac OS, define it as a bash function if it's not found
+if [ ! -f "/usr/bin/realpath" ] && [ ! -f "/bin/realpath" ]; then
+    realpath() {
+        [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+    }
+fi
+
 # Parse arguments
 while [[ $# -ge 1 ]]; do
 	i="$1"


### PR DESCRIPTION
Running resinos-in-container.sh on Mac OS `x fails at `config_json="$(realpath "$2")"` as realpath is not part of the default distribution.

This adds a check if /usr/bin/realpath or /bin/realpath exist, and if not, defines it as a bash function.

TIL: Mac OS excludes everything GPL3 due to licensing issues apparently which leads to some old versions of- or entirely missing gnu tools.